### PR TITLE
WFK2-194: mention Graphene instead of Ajocado.

### DIFF
--- a/Developer_Guide/src/main/docbook/en-US/chap-Developer_Guide-Getting_started_with_RichFaces.xml
+++ b/Developer_Guide/src/main/docbook/en-US/chap-Developer_Guide-Getting_started_with_RichFaces.xml
@@ -479,7 +479,7 @@
                         If you want to test JSF from client's perspective with ability to access state of JSF internals, use <ulink url="http://www.jboss.org/jsfunit"><productname>JBoss JSFUnit project</productname></ulink> (with Arquillian integration).  
                     </para>
                     <para>
-                        For automation of client-side tests in real-browser, you may want to employ <ulink url="http://community.jboss.org/wiki/ArquillianAjocado"><productname>Arquillian Ajocado</productname></ulink> and <ulink url="https://docs.jboss.org/author/display/ARQ/Drone"><productname>Arquillian Drone</productname></ulink> extensions.
+                        For automation of client-side tests in real-browser, you may want to employ <ulink url="https://docs.jboss.org/author/display/ARQGRA2/Home"><productname>Arquillian Graphene</productname></ulink> and <ulink url="https://docs.jboss.org/author/display/ARQ/Drone"><productname>Arquillian Drone</productname></ulink> extensions.
                     </para>
                     <para>
                         For mocking JSF environment, there is set of tools in RichFaces <productname>jsf-test</productname> project. For full details on how to use the <productname>jsf-test</productname> project, refer to article <ulink url="http://community.jboss.org/docs/DOC-13155">Test Driven JSF Development</ulink>.


### PR DESCRIPTION
Hi Brian, this is a pull request for the changes I did a while ago in enterprise docs. It removes a mention of Ajocado and replaces it with a mention of Graphene.
